### PR TITLE
ci: allow garnix to compile `tsodingPackages`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,8 +11,6 @@ check-nur-eval:
 check-formatting:
     nix fmt -- --ci
 
-# TODO: in CI, only rebuild the package that changed
-# this doesn't have a lot of packages right now so should be fine
 build-test:
     #!/usr/bin/env bash
     if [ -z "$CI" ]; then

--- a/ci.nix
+++ b/ci.nix
@@ -15,8 +15,8 @@
 
 with builtins;
 let
+  flattenPkgs = import lib/flatten.nix;
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
-  isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
   isBuildable =
     p:
     let
@@ -25,7 +25,6 @@ let
     in
     !(p.meta.broken or false) && builtins.all (license: license.free or true) licenseList;
   isCacheable = p: !(p.preferLocalBuild or false);
-  shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
 
   nameValuePair = n: v: {
     name = n;
@@ -33,20 +32,6 @@ let
   };
 
   concatMap = builtins.concatMap or (f: xs: concatLists (map f xs));
-
-  flattenPkgs =
-    s:
-    let
-      f =
-        p:
-        if shouldRecurseForDerivations p then
-          flattenPkgs p
-        else if isDerivation p then
-          [ p ]
-        else
-          [ ];
-    in
-    concatMap f (attrValues s);
 
   outputsOf = p: map (o: p.${o}) p.outputs;
 

--- a/ci.nix
+++ b/ci.nix
@@ -15,7 +15,7 @@
 
 with builtins;
 let
-  flattenPkgs = import lib/flatten.nix;
+  flattenPkgs = import lib/flatten.nix { inherit pkgs; };
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
   isBuildable =
     p:
@@ -37,9 +37,12 @@ let
 
   nurAttrs = import ./default.nix { inherit pkgs; };
 
-  nurPkgs = flattenPkgs (
-    listToAttrs (
-      map (n: nameValuePair n nurAttrs.${n}) (filter (n: !isReserved n) (attrNames nurAttrs))
+  # TODO: could be more succinct
+  nurPkgs = pkgs.lib.attrsToList (
+    flattenPkgs (
+      listToAttrs (
+        map (n: nameValuePair n nurAttrs.${n}) (filter (n: !isReserved n) (attrNames nurAttrs))
+      )
     )
   );
 in

--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,8 @@
       let
         pkgs = import nixpkgs { inherit system; };
         defaultNix = (import ./. { inherit pkgs; });
-        # HACK: I don't know how to make `nix flake show` not scream at me without doing this
-        flakePackages =
-          with pkgs.lib;
-          mapAttrs (_: p: if !isDerivation p then filterAttrs (_: isDerivation) p else p) (
-            filterAttrs (_: p: isDerivation p || isAttrs p) defaultNix
-          );
+        flattenPkgs = (import lib/flatten.nix { inherit pkgs; });
+        flakePackages = flattenPkgs defaultNix;
         warnPackages =
           if system != "x86_64-linux" then
             pkgs.lib.warn "dtomvan/nur-packages: only x86_64-linux builds are tested, use at own risk" flakePackages

--- a/lib/flatten.nix
+++ b/lib/flatten.nix
@@ -1,0 +1,19 @@
+with builtins;
+let
+  isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
+  shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
+  flattenPkgs =
+    s:
+    let
+      f =
+        p:
+        if shouldRecurseForDerivations p then
+          flattenPkgs p
+        else if isDerivation p then
+          [ p ]
+        else
+          [ ];
+    in
+    concatMap f (attrValues s);
+in
+flattenPkgs

--- a/lib/flatten.nix
+++ b/lib/flatten.nix
@@ -1,19 +1,21 @@
+{ pkgs }:
 with builtins;
 let
   isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
   shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
-  flattenPkgs =
+  flattenPkgs_ =
     s:
     let
       f =
         p:
-        if shouldRecurseForDerivations p then
-          flattenPkgs p
-        else if isDerivation p then
+        if shouldRecurseForDerivations p.value then
+          flattenPkgs_ (pkgs.lib.attrsToList p.value)
+        else if isDerivation p.value then
           [ p ]
         else
           [ ];
     in
-    concatMap f (attrValues s);
+    concatMap f s;
+  flattenPkgs = s: listToAttrs (flattenPkgs_ (pkgs.lib.attrsToList s));
 in
 flattenPkgs


### PR DESCRIPTION
Exposes them in `packages` too so that `nix flake show --json` will return them to garnix. Apparently garnix does not build packages if they don't exist inside of the flake and does not care about `legacyPackages`.