### PR TITLE
updates 2026-04-11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775126147,
-        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
+        "lastModified": 1775823930,
+        "narHash": "sha256-ALT447J7FcxP/97J01A/gp/hgdO5lXRsm+zLMt+gIjc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
+        "rev": "8c11f88bb9573a10a7d6bf87161ef08455ac70b9",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1775125835,
-        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "75925962939880974e3ab417879daffcba36c4a3",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/pkgs/obsidian-web-clipper/package.nix
+++ b/pkgs/obsidian-web-clipper/package.nix
@@ -9,16 +9,16 @@
 let
   xpifile = buildNpmPackage (finalAttrs: {
     pname = "obsidian-web-clipper";
-    version = "1.3.0";
+    version = "1.4.0";
 
     src = fetchFromGitHub {
       owner = "obsidianmd";
       repo = "obsidian-clipper";
       rev = finalAttrs.version;
-      hash = "sha256-32ekfFsk7uzfvlyhpbzKXL/cjsTOpk7sXCzbzr3mXms=";
+      hash = "sha256-jnW52ijsCXbxU/Yz0xWw37fxaVCB8gBMRTwa4QUuyFU=";
     };
 
-    npmDepsHash = "sha256-zidaPnjSIqSPRhprIJbR4Mc4dcO+RNmrb6o9DiWGBnI=";
+    npmDepsHash = "sha256-APgIEqsY7LnMeJ/becvS7upsmQw9ksb1K66zFW7hqqY=";
     npmBuildScript = "build:firefox";
 
     installPhase = ''


### PR DESCRIPTION
- 97ea9dd obsidian-web-clipper: 1.3.0 -> 1.4.0
- 9aeae05 chore: nix flake update
